### PR TITLE
Don't die on "pong" response

### DIFF
--- a/ewelink/ws.py
+++ b/ewelink/ws.py
@@ -1,4 +1,4 @@
-import aiohttp, time, random, asyncio
+import aiohttp, time, random, asyncio, json
 
 from typing import AnyStr, TypedDict
 
@@ -84,7 +84,10 @@ class WebSocketClient:
 
     async def poll_event(self):
         while True:
-            msg: dict[str, dict[str, bool | AnyStr] | AnyStr] = await self.ws.receive_json()
+            received = await self.ws.receive_str()
+            if received == 'pong':
+                continue
+            msg: dict[str, dict[str, bool | AnyStr] | AnyStr] = json.loads(received)
             if action := msg.get('action', None):
                 match action:
                     case "sysmsg":


### PR DESCRIPTION
To reproduce, make a script that:

1. Logs in
1. Successfully powers something on or off.
1. Sleeps/awaits some other resource until `ping_hb()` has run at least once (> 152 seconds for me)
1. Tries a power on or off command

It fails with some combination of `TimeoutError` and `CancelledError`, and after I Ctrl-c the script I see a JSON parse error at character 0 happening on the line in the patch below.

With this patch, my long-lived script is happy - specifically I'm watching the Hue event stream for button-presses with aiohue `bridge.subscribe(handler)`.
